### PR TITLE
Add type hints for GraalVM

### DIFF
--- a/src/clojure_ini/core.clj
+++ b/src/clojure_ini/core.clj
@@ -2,8 +2,8 @@
   (:require [clojure.string :as s]
             [clojure.java.io :as io]))
 
-(defn- parse-line [s kw trim]
-  (if (= (first s) \[) 
+(defn- parse-line [^String s kw trim]
+  (if (= (first s) \[)
     (-> s (subs 1 (.indexOf s "]")) trim kw)
     (let [n (.indexOf s "=")]
       (if (neg? n)
@@ -11,7 +11,7 @@
         [(-> s (subs 0 n) trim kw)
          (-> s (subs (inc n)) trim)]))))
 
-(defn- strip-comment [s chr allow-anywhere?]
+(defn- strip-comment [^String s chr allow-anywhere?]
   (let [n (.indexOf s (int chr))]
     (if (and (not (neg? n))
              (or allow-anywhere?
@@ -60,6 +60,6 @@
     (with-open [r (io/reader in)]
       (->> (line-seq r)
            (map #(strip-comment % comment-char allow-comments-anywhere?))
-           (remove (fn [s] (every? #(Character/isWhitespace %) s)))
+           (remove (fn [s] (every? #(Character/isWhitespace ^char %) s)))
            (map #(parse-line % kw trim))
            mapify))))


### PR DESCRIPTION
Hi!

First, thank you for a useful library!

I'm writing a CLI application using Clojure and GraalVM. The application reads its config from an INI file. The problem is, GraalVM feels bad when facing Clojure reflection. This PR adds three type hints to make the compiler happy. With these changes, everything works in Graal.

Could you please accept these changes and make a new release in Clojars? I will highly appreciate this.



